### PR TITLE
Fixes value of main in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jquery.longclick",
   "version": "1.0.0",
   "description": "This jQuery plugin adds capability to long-click on selected elements, just as a long tap on, say, a mobile device.",
-  "main": "demo/demo.html",
+  "main": "plugin/jquery.longclick-1.0.js",
   "scripts": {
     "test": ""
   },


### PR DESCRIPTION
As documented both on the [npm website](https://docs.npmjs.com/files/package.json#main) the value of `main` in `package.json` should point to the entry point of the program. Pointing `main` at `plugin/jquery.longclick-1.0.jsl` allows people to do
```
import 'jquery.longclick';
```
instead of
```
import 'jquery.longclick/plugin/jquery.longclick-1.0';
```